### PR TITLE
Download dependencies before running golangci-lint

### DIFF
--- a/.github/workflows/run_linters.yaml
+++ b/.github/workflows/run_linters.yaml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '^1.17.7'
+      run: go mod tidy
 
     - name: Lint
       uses: golangci/golangci-lint-action@v2


### PR DESCRIPTION
Currently, golangci-lint is failing with the following error:
> level=error msg="Running error: context loading failed: no go files to analyze"

This is probably due to some dependencies not being available when it tries to run.
