### PR TITLE
Update golangci lint version

### DIFF
--- a/.github/workflows/run_linters.yaml
+++ b/.github/workflows/run_linters.yaml
@@ -11,14 +11,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
         go-version: '^1.16.14'
-
+        check-latest: false
+    - uses: actions/checkout@v2
     - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.44.2
+        version: v1.45.1


### PR DESCRIPTION
The previously used version was not working correctly with go 1.17 and go 1.18