### PR TITLE
start using org_id instead of account_number

### DIFF
--- a/base/models/models.go
+++ b/base/models/models.go
@@ -8,8 +8,9 @@ import (
 
 // Account table
 type Account struct {
-	ID   int64  `gorm:"type:bigint;primaryKey;autoIncrement"`
-	Name string `gorm:"type:text"`
+	ID            int64  `gorm:"type:bigint;primaryKey;autoIncrement"`
+	AccountNumber string `gorm:"type:text"`
+	OrgID         string `gorm:"type:text"`
 }
 
 func (a Account) TableName() string {

--- a/dbadmin/migrations/005_org_id.down.sql
+++ b/dbadmin/migrations/005_org_id.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE account DROP COLUMN org_id;
+ALTER TABLE account DROP COLUMN account_number;
+ALTER TABLE account ADD COLUMN name TEXT NOT NULL UNIQUE CHECK (NOT empty(name));

--- a/dbadmin/migrations/005_org_id.up.sql
+++ b/dbadmin/migrations/005_org_id.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE account DROP COLUMN name;
+ALTER TABLE account ADD COLUMN account_number TEXT NOT NULL UNIQUE CHECK (NOT empty(account_number));
+ALTER TABLE account ADD COLUMN org_id TEXT NOT NULL UNIQUE CHECK (NOT empty(org_id));

--- a/dbadmin/testing_data.sql
+++ b/dbadmin/testing_data.sql
@@ -5,11 +5,11 @@
 -- This is intended to be temporary until we get full flow working with
 -- real data.
 -- ----------------------------------------------------------------------------
-INSERT INTO account (id, name) VALUES
-(13, '13'),
-(14, '14'),
-(30, '30'),
-(31, '31');
+INSERT INTO account (id, account_number, org_id) VALUES
+(13, '13', '013'),
+(14, '14', '014'),
+(30, '30', '030'),
+(31, '31', '031');
 
 INSERT INTO cluster (id, uuid, status, version, provider, account_id, cve_cache_critical, cve_cache_important, cve_cache_moderate, cve_cache_low) VALUES
 (15, 'daac83ee-a390-420d-b892-cb9e1d006eca', 'ready'   , 'v_01', 'prov_1', 13, 0, 0, 0, 0),

--- a/manager/middlewares/authenticator.go
+++ b/manager/middlewares/authenticator.go
@@ -68,15 +68,15 @@ func Authenticate(db *gorm.DB) gin.HandlerFunc {
 		}
 
 		var acc models.Account
-		res := db.Where("name = ?", id.Identity.AccountNumber).Find(&acc)
+		res := db.Where("org_id = ?", id.Identity.OrgID).Find(&acc)
 
 		if res.RowsAffected > 0 {
 			ctx.Set("account_id", acc.ID)
-			ctx.Set("account_number", id.Identity.AccountNumber)
+			ctx.Set("org_id", id.Identity.OrgID)
 		} else {
 			// set non-existing account_id, so account with empty systems, can still get response with empty data
 			ctx.Set("account_id", int64(-1))
-			ctx.Set("account_number", id.Identity.AccountNumber)
+			ctx.Set("org_id", id.Identity.OrgID)
 		}
 	}
 }

--- a/manager/middlewares/logger.go
+++ b/manager/middlewares/logger.go
@@ -29,7 +29,7 @@ func Logger() gin.HandlerFunc {
 			"method":    ctx.Request.Method,
 			"status":    ctx.Writer.Status(),
 			"duration":  duration.String(),
-			"acc_num":   ctx.GetString("account_number"),
+			"org_id":    ctx.GetString("org_id"),
 		})
 		if ctx.Writer.Status() < http.StatusInternalServerError {
 			entry.Info(ctx.Request.RequestURI)


### PR DESCRIPTION
- Account number is still present in DB, not sure if it's beneficial to drop it, more information in DB is always good for debugging and it's provided by sha-extractor for free.
- Manager is also expecting account number in the header, even if it doesn't use it, should it be removed?

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
