### PR TITLE
Fix digestwriter GORM operations

### DIFF
--- a/digestwriter/consumer_test.go
+++ b/digestwriter/consumer_test.go
@@ -253,16 +253,18 @@ func setHappyPathExpectations(mock sqlmock.Sqlmock) {
 	// expected SQL statements during this test [SIMPLIFIED. This behavior is tested in storage_test.go]
 	expectedSelectFromAccount := `SELECT * FROM "account"`
 	expectedInsertIntoAccount := `INSERT INTO "account"`
+	expectedSelectFromCluster := `SELECT "cluster"."id","cluster"."uuid","cluster"."account_id" FROM "cluster"`
 	expectedInsertIntoCluster := `INSERT INTO "cluster"`
 	expectedSelectFromImage := `SELECT * FROM "image"`
 	expectedInsertIntoClusterImage := `INSERT INTO "cluster_image"`
 
 	mock.ExpectBegin()
 	mock.ExpectQuery(regexp.QuoteMeta(expectedSelectFromAccount)).
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}))
 	mock.ExpectQuery(regexp.QuoteMeta(expectedInsertIntoAccount)).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	mock.ExpectQuery(regexp.QuoteMeta(expectedSelectFromCluster)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}))
 	mock.ExpectQuery(regexp.QuoteMeta(expectedInsertIntoCluster)).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
 	mock.ExpectQuery(regexp.QuoteMeta(expectedSelectFromImage)).


### PR DESCRIPTION
- Simplify "FirstOrCreate" call to ensure it works as expected despite the tables' content
- sha_generator fixes:
  - Commit or rollback the 'store' transaction
  - make pyxis_id really random to avoid errors when inserting
  - formatting 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
