### PR TITLE
Add KAFKA_BROKER_ADDRESS env var to digestwriter deployment file

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -128,6 +128,8 @@ objects:
               name: vuln4shift-db-passwds
         - name: LOGGING_LEVEL
           value: ${LOGGING_LEVEL}
+        - name: KAFKA_BROKER_ADDRESS
+          value: ${KAFKA_BOOTSTRAP_HOST}:${KAFKA_BOOTSTRAP_PORT}
         - name: KAFKA_BROKER_INCOMING_TOPIC
           value: ${KAFKA_BROKER_INCOMING_TOPIC}
         - name: KAFKA_BROKER_CONSUMER_GROUP
@@ -341,6 +343,15 @@ parameters:
   value: release
 
 # DIGEST WRITER CONFIG
+- name: KAFKA_BOOTSTRAP_HOST
+  description: Kafka broker host address
+  required: true
+  value: mq-kafka
+- name: KAFKA_BOOTSTRAP_PORT
+  description: Kafka broker host port
+  required: true
+  value: '29092'
+
 - name: KAFKA_BROKER_CONSUMER_GROUP
   description: Consumer group for the kafka
   required: true
@@ -351,8 +362,7 @@ parameters:
   value: ccx.image.sha.results
 - name: KAFKA_CONSUMER_TIMEOUT
   description: Timeout for kafka consumer
-  required: true
-  value: "0s"
+  required: false
 
 # VMAAS SYNC CONFIG
 - name: VMAAS_BASE_URL


### PR DESCRIPTION
Without this environment variable, the digestwriter service cannot connect to the correct Kafka broker