### PR TITLE
Use two pods for digestwriter and fix number of consumed partitions

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -28,7 +28,7 @@ objects:
     envName: ${ENV_NAME}
     kafkaTopics:
     - replicas: 3
-      partitions: 3
+      partitions: 2
       topicName: ${KAFKA_BROKER_INCOMING_TOPIC}
     dependencies: []
 
@@ -234,7 +234,7 @@ parameters:
 - name: REPLICAS_DIGEST_WRITER
   description: digest writer replica count
   required: true
-  value: "3"
+  value: "2"
 
 # RESOURCES
 - name: CPU_REQUEST_MANAGER


### PR DESCRIPTION
Adapting the number of replicas and the Kafka incoming topic configuration to https://github.com/RedHatInsights/platform-mq/blob/master/topics/topics.json#L27