### PR TITLE
rename digestwriter's Kafka consumer group

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -134,7 +134,7 @@ objects:
         - name: KAFKA_BROKER_INCOMING_TOPIC
           value: ${KAFKA_BROKER_INCOMING_TOPIC}
         - name: KAFKA_BROKER_CONSUMER_GROUP
-          value: ${KAFKA_BROKER_CONSUMER_GROUP}
+          value: ${DIGEST_WRITER_CONSUMER_GROUP}
         - name: KAFKA_CONSUMER_TIMEOUT
           value: ${KAFKA_CONSUMER_TIMEOUT}
         - name: GIN_MODE


### PR DESCRIPTION
Fix typo included in a previous MR

The idea is to use specific group names so we don't mistakenly end up with more consumers in a group than expected.