### PR TITLE
fix(digestwriter): accept multiple account number types including empty strings

### DIFF
--- a/base/utils/payload_tracker.go
+++ b/base/utils/payload_tracker.go
@@ -27,11 +27,6 @@ type PayloadTrackerEvent struct {
 	Date        *string `json:"date"` // RFC3339
 }
 
-func (e *PayloadTrackerEvent) SetOrgIDFromUint(id json.Number) {
-	orgID := id.String()
-	e.OrgID = &orgID
-}
-
 func (e *PayloadTrackerEvent) SetRequestID(id string) {
 	e.RequestID = &id
 }
@@ -71,10 +66,10 @@ func (e *PayloadTrackerEvent) SendKafkaMessage(producer Producer) error {
 	return producer.SendMessage(sarama.StringEncoder(*e.RequestID), sarama.ByteEncoder(bs))
 }
 
-func NewPayloadTrackerEvent(reqID string) PayloadTrackerEvent {
+func NewPayloadTrackerEvent(reqID, orgID string) PayloadTrackerEvent {
 	return PayloadTrackerEvent{
 		Service:     service,
-		OrgID:       nil,
+		OrgID:       &orgID,
 		RequestID:   &reqID,
 		InventoryID: "",
 		Status:      "",

--- a/base/utils/payload_tracker_test.go
+++ b/base/utils/payload_tracker_test.go
@@ -28,7 +28,7 @@ func TestSendPayloadTrackerMessage(t *testing.T) {
 	testProducer := CreateKafkaProducerMock(topic, testWriter)
 	defer testProducer.Close()
 
-	ptEvent := NewPayloadTrackerEvent("test-key")
+	ptEvent := NewPayloadTrackerEvent("test-key", "1234567")
 
 	assert.Nil(t, ptEvent.SendKafkaMessage(testProducer))
 	awaitPayloadTrackerValidResponse(t, testProducer, time.Millisecond*500, 0)
@@ -38,7 +38,7 @@ func TestSendPayloadTrackerMessage(t *testing.T) {
 }
 
 func TestPayloadTrackerStatusUpdate(t *testing.T) {
-	ptEvent := NewPayloadTrackerEvent("key")
+	ptEvent := NewPayloadTrackerEvent("key", "1234567")
 
 	ptEvent.UpdateStatusReceived()
 	assert.Equal(t, PayloadTrackerStatusReceived, ptEvent.Status)

--- a/digestwriter/storage.go
+++ b/digestwriter/storage.go
@@ -6,7 +6,6 @@ package digestwriter
 import (
 	"app/base/models"
 	"app/base/utils"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -22,7 +21,7 @@ const (
 
 // Storage represents an interface to almost any database or storage system
 type Storage interface {
-	WriteClusterInfo(cluster ClusterName, orgID json.Number, workload Workload, digests []string) error
+	WriteClusterInfo(cluster ClusterName, orgID AccountNumber, workload Workload, digests []string) error
 }
 
 // DBStorage is an implementation of Storage
@@ -190,7 +189,7 @@ func (storage *DBStorage) linkDigestsToCluster(tx *gorm.DB, clusterStr string, c
 }
 
 // WriteClusterInfo updates the 'cluster' table with the provided info
-func (storage *DBStorage) WriteClusterInfo(cluster ClusterName, orgID json.Number, workload Workload, digests []string) error {
+func (storage *DBStorage) WriteClusterInfo(cluster ClusterName, orgID AccountNumber, workload Workload, digests []string) error {
 	// prepare data
 	clusterStr := string(cluster)
 	clusterUUID, err := uuid.Parse(clusterStr)
@@ -199,7 +198,7 @@ func (storage *DBStorage) WriteClusterInfo(cluster ClusterName, orgID json.Numbe
 		return err
 	}
 	accountData := models.Account{
-		OrgID: fmt.Sprint(orgID),
+		OrgID: string(orgID),
 	}
 
 	logger.WithFields(logrus.Fields{

--- a/digestwriter/storage_test.go
+++ b/digestwriter/storage_test.go
@@ -7,7 +7,6 @@ import (
 	"app/base/models"
 	"app/digestwriter"
 	"database/sql"
-	"encoding/json"
 	"regexp"
 	"testing"
 	"time"
@@ -23,7 +22,7 @@ var (
 	digestModifiedAtTime = time.Now().UTC()
 	clusterName          = digestwriter.ClusterName("84f7eedc-0000-0000-9d4d-000000000000")
 	invalidClusterName   = digestwriter.ClusterName("99z7zzzz-0000-0000-9d4d-000000000000")
-	testOrgID            = json.Number("1")
+	testOrgID            = digestwriter.AccountNumber("1")
 	workload             = digestwriter.Workload{}
 
 	anyArgForMockSQLQueries = sqlmock.AnyArg()


### PR DESCRIPTION
VULN4OS-199

Unmarshalls like `json.Number` but handles empty strings.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
